### PR TITLE
Fix global install

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,9 @@
+{
+  "presets": [
+    "es2015"
+  ],
+  "plugins": [
+    "transform-object-rest-spread",
+    "transform-object-assign"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -34,15 +34,6 @@
     "start": "browser-sync start --config bs-config.js",
     "postinstall": "npm run mkdirs && npm run build"
   },
-  "babel": {
-    "presets": [
-      "es2015"
-    ],
-    "plugins": [
-      "transform-object-rest-spread",
-      "transform-object-assign"
-    ]
-  },
   "devDependencies": {
     "autoprefixer": "^6.3.3",
     "babel-cli": "^6.5.1",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "start": "browser-sync start --config bs-config.js",
     "postinstall": "npm run mkdirs && npm run build"
   },
-  "devDependencies": {
+  "dependencies": {
     "autoprefixer": "^6.3.3",
     "babel-cli": "^6.5.1",
     "babel-plugin-transform-object-assign": "^6.5.0",


### PR DESCRIPTION
Running `npm i -g gsq` fails.

First, it fails when the `postinstall` npm task is ran. Since all dependencies were marked as devDependencies gsq will not have any dependencies installed. Changing devDependencies to dependencies fixes this. Technically, `browser-sync` could probably still be a devDependency.

Once gsq is installed successfully, the command fails due to the babel-register hook not loading a Babel config to properly load `.bin/es6-cli.js`. Apparently the babel-register hook will look for the closest `.babelrc`, not `package.json`. [[1]](https://babeljs.io/docs/usage/require/) This was a pretty big surprise to me, but seems to be the cause.

I made these as separate commits, but I can squash them if you'd prefer.
